### PR TITLE
Update Workspace to use Resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "source/river",
 ]


### PR DESCRIPTION
This is a follow-on to #20, updating the workspace to use the 2021-crate-default of resolver 2.

See https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions for more details.