### PR TITLE
Update Pingora Version

### DIFF
--- a/source/river/Cargo.toml
+++ b/source/river/Cargo.toml
@@ -62,22 +62,22 @@ features = [
 #
 # git = "https://github.com/cloudflare/pingora"
 #
-# NOTE: currently tracking https://github.com/cloudflare/pingora/pull/165
+# NOTE: currently tracking https://github.com/cloudflare/pingora/pull/218
 git = "https://github.com/memorysafety/pingora"
-rev = "a8a476eefb4703a2996dbe118778fb0e7539d348"
+rev = "8727b2466f9a11aec6c5386c61c51ce54946b962"
 # path = "../../../pingora/pingora"
 
 [dependencies.pingora-core]
 git = "https://github.com/memorysafety/pingora"
-rev = "a8a476eefb4703a2996dbe118778fb0e7539d348"
+rev = "8727b2466f9a11aec6c5386c61c51ce54946b962"
 # path = "../../../pingora/pingora-core"
 
 [dependencies.pingora-proxy]
 git = "https://github.com/memorysafety/pingora"
-rev = "a8a476eefb4703a2996dbe118778fb0e7539d348"
+rev = "8727b2466f9a11aec6c5386c61c51ce54946b962"
 # path = "../../../pingora/pingora-proxy"
 
 [dependencies.pingora-http]
 git = "https://github.com/memorysafety/pingora"
-rev = "a8a476eefb4703a2996dbe118778fb0e7539d348"
+rev = "8727b2466f9a11aec6c5386c61c51ce54946b962"
 # path = "../../../pingora/pingora-http"


### PR DESCRIPTION
This is working towards a released version of `pingora`, so that we can make a 0.2 release of the current state.

blocked on: https://github.com/cloudflare/pingora/pull/218