### PR TITLE
Update release.yml to remove extraneous pieces from the "install" command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.2/cargo-dist-installer.sh | sh"
+        run: "curl -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.2/cargo-dist-installer.sh | sh"
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.


### PR DESCRIPTION
Remove extraneous proto option and also don't specify TLS version to ensure ability to use 1.3 that is already available.
1. There's no need to specify the proto option if you're specifying `https` in the URL
2. GitHub already supports TLS 1.3. Let's not pin this to a TLS version. Allow cURL to properly use TLS 1.3 if support has been compiled in for their distro.