### PR TITLE
Docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,32 @@
 
 ## Current State
 
-As part of the initial [Kickstart Spike], we are working towards an early preview of
-the `river` tool.
+We reached the [initial v0.2.0 release] at the end of April (and a small [v0.2.1 release]
+for crates.io availability in May), completing the work in [Kickstart Spike 1].
 
-[Kickstart Spike]: https://github.com/memorysafety/river/milestone/1
+As of the end of May, work towards the next features in [Kickstart Spike 2] have begun.
+
+The next work is focused on:
+
+1. Development of "multiple upstream" features, including:
+    * Supporting Load Balancing of upstream servers
+    * Supporting Health Checks of upstream servers
+    * Supporting Service Discovery of upstream servers
+2. Developer and Operator Quality of Life features, including:
+    * Supporting basic static HTML file serving
+    * Supporting semi-dynamic observability endpoints, e.g. for Prometheus polling
+    * Support for hot-reloading of configuration
+    * CI for build and test checks on pull requests
+3. Development of initial Robustness features, including:
+    * Rate limiting of connections and/or requests
+    * CIDR/API range-based filtering for rejecting connections
+
+Stay tuned for updates on these features!
+
+[initial v0.2.0 release]: https://github.com/memorysafety/river/releases/tag/v0.2.0
+[v0.2.1 release]: https://github.com/memorysafety/river/releases/tag/v0.2.1
+[Kickstart Spike 1]: https://github.com/memorysafety/river/milestone/1
+[Kickstart Spike 2]: https://github.com/memorysafety/river/milestone/3
 
 **Until further notice, there is no expectation of stability.**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 We reached the [initial v0.2.0 release] at the end of April (and a small [v0.2.1 release]
 for crates.io availability in May), completing the work in [Kickstart Spike 1].
 
-As of the end of May, work towards the next features in [Kickstart Spike 2] have begun.
+As of the end of May, work towards the next features in [Kickstart Spike 2] has begun.
 
 The next work is focused on:
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,17 @@
+# Release Checklist
+
+The following is the release checklist for each version of `river`.
+
+* [ ] Open a PR changing the version of `river` in `Cargo.toml`, and adding a
+      document to the `docs/release-notes` containing the major changes in
+      this release.
+* [ ] Merge the PR
+* [ ] Locally, pull the up to date `main` branch
+* [ ] Tag the commit with `git tag vX.Y.Z`
+* [ ] Push the tag to github with `git push origin --tags`
+* [ ] Wait for the `cargo-dist` job to complete.
+    * This will create the release on github
+* [ ] Release to crates.io using `cargo publish`
+* [ ] Edit the release on github, using the "Generate release notes" feature.
+      Move the generated "What's Changed" section to the top of the release.
+* [ ] Announce the release in various places

--- a/docs/release-notes/2024-06-03-v0.2.1.md
+++ b/docs/release-notes/2024-06-03-v0.2.1.md
@@ -1,0 +1,28 @@
+# River v0.2.1
+
+River is a reverse proxy application written in Rust, supported as a [Prossimo Initiative],
+built on top of the [Pingora engine] from Cloudflare. River began development in Q1 2024,
+and is currently in an early developer preview state.
+
+[Prossimo Initiative]: https://www.memorysafety.org/initiative/reverse-proxy/
+[Pingora engine]: https://github.com/cloudflare/pingora
+
+This announcement covers the v0.2.1 release of River. This is a minor release that
+switches to the v0.2.0 crates.io release of `pingora`, in order to allow for the
+release of `river` on crates.io. You can now find [`river` on crates.io].
+
+[`river` on crates.io]: https://crates.io/crates/river/0.2.1
+
+This release was led by [OneVariable UG], and sponsored by [Prossimo][Prossimo Initiative].
+
+[OneVariable UG]: https://onevariable.com/
+
+For installation instructions, see [the release details on GitHub]. This release includes
+binaries for x86_64 Linux (GNU and MUSL builds), as well as a release for aarch64 MacOS
+(M-series Macs). Binaries are provided, as well as an installation script. Release tooling
+is provided by [`cargo-dist`].
+
+[the release details on GitHub]: https://github.com/memorysafety/river/releases/tag/v0.2.1
+[`cargo-dist`]: https://github.com/axodotdev/cargo-dist
+
+## Notable features

--- a/source/river/Cargo.toml
+++ b/source/river/Cargo.toml
@@ -1,11 +1,5 @@
 [package]
 name          = "river"
-
-# VERSION NOTE:
-#
-# Once we have our first crates-io release, we should yank the v0.1
-# placeholder release. At the moment, we can't publish on crates-io
-# as we are carrying patches of pingora.
 version       = "0.2.1"
 
 authors       = [


### PR DESCRIPTION
This PR updates the README and Cargo.toml with the current status of the project.

This PR also adds the missing v0.2.1 changelog, as well as a small release checklist so I don't forget the release notes a third time.