### PR TITLE
Update pingora and pandora-web-server dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,35 +27,35 @@ lto = "thin"
 
 [patch.crates-io.pingora-load-balancing]
 git = "https://github.com/memorysafety/pingora.git"
-rev = "12ca93c6b187a68ff9a526b4c4e669f602244366"
+rev = "a98eadde498a45f32ab906d629342954fa173d11"
 # path = "../pingora/pingora-load-balancing"
 
 [patch.crates-io.pingora-core]
 git = "https://github.com/memorysafety/pingora.git"
-rev = "12ca93c6b187a68ff9a526b4c4e669f602244366"
+rev = "a98eadde498a45f32ab906d629342954fa173d11"
 # path = "../pingora/pingora-core"
 
 [patch.crates-io.pingora-cache]
 git = "https://github.com/memorysafety/pingora.git"
-rev = "12ca93c6b187a68ff9a526b4c4e669f602244366"
+rev = "a98eadde498a45f32ab906d629342954fa173d11"
 # path = "../pingora/pingora-cache"
 
 [patch.crates-io.pingora-http]
 git = "https://github.com/memorysafety/pingora.git"
-rev = "12ca93c6b187a68ff9a526b4c4e669f602244366"
+rev = "a98eadde498a45f32ab906d629342954fa173d11"
 # path = "../pingora/pingora-http"
 
 [patch.crates-io.pingora-proxy]
 git = "https://github.com/memorysafety/pingora.git"
-rev = "12ca93c6b187a68ff9a526b4c4e669f602244366"
+rev = "a98eadde498a45f32ab906d629342954fa173d11"
 # path = "../pingora/pingora-proxy"
 
 [patch.crates-io.static-files-module]
-git = "https://github.com/jamesmunns/pandora-web-server.git"
-rev = "f3a84be5d3be0daa65303f62aa01d0b57e7cc708"
+git = "https://github.com/pandora-web-server/pandora-web-server.git"
+rev = "fe5d7dfc7d943d2bd8371309084a775db99e84f0"
 # path = "../pandora-web-server/static-files-module"
 
 [patch.crates-io.pandora-module-utils]
-git = "https://github.com/jamesmunns/pandora-web-server.git"
-rev = "f3a84be5d3be0daa65303f62aa01d0b57e7cc708"
+git = "https://github.com/pandora-web-server/pandora-web-server.git"
+rev = "fe5d7dfc7d943d2bd8371309084a775db99e84f0"
 # path = "../pandora-web-server/pandora-module-utils"

--- a/source/river/Cargo.toml
+++ b/source/river/Cargo.toml
@@ -33,6 +33,7 @@ kdl = "4.6.0"
 miette = { version = "5.10.0", features = ["fancy"] }
 thiserror = "1.0.61"
 http = "1.0.0"
+futures-util = "0.3.30"
 
 [dependencies.static-files-module]
 version = "0.2"
@@ -62,16 +63,16 @@ features = [
 # Pingora dependencies
 
 [dependencies.pingora]
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies.pingora-core]
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies.pingora-proxy]
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies.pingora-http]
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies.pingora-load-balancing]
-version = "0.2.0"
+version = "0.3.0"

--- a/source/river/src/files.rs
+++ b/source/river/src/files.rs
@@ -21,6 +21,7 @@ pub fn river_file_server(
         index_file: Vec::new().into(),
         page_404: None,
         precompressed: Vec::new().into(),
+        ..Default::default()
     };
     let file_server = FileServer {
         server: StaticFilesHandler::try_from(fsconf)


### PR DESCRIPTION
This updates us to using pingora v0.3, plus one additional patch by @eaufavor that adds dynamic backend metadata.

We also updated pandora-web-server git dependency to a version based on pingora.

Closes #51 