### PR TITLE
support show version ( --version )

### DIFF
--- a/source/river/src/config/cli.rs
+++ b/source/river/src/config/cli.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 /// River: A reverse proxy from Prossimo
 #[derive(Parser, Debug)]
+#[clap(version)]
 pub struct Cli {
     /// Validate all configuration data and exit
     #[arg(long)]


### PR DESCRIPTION
support show version ( --version )

```
❯ cargo run -- --help 2>/dev/null
2025-01-27T16:02:44.950107Z  INFO river::config: Parsing CLI options
River: A reverse proxy from Prossimo

Usage: river [OPTIONS]

Options:
      --validate-configs
          Validate all configuration data and exit
      --config-toml <CONFIG_TOML>
          Path to the configuration file in TOML format
      --config-kdl <CONFIG_KDL>
          Path to the configuration file in KDL format
      --threads-per-service <THREADS_PER_SERVICE>
          Number of threads used in the worker pool for EACH service
      --daemonize
          Should the server be daemonized after starting?
      --upgrade
          Should the server take over an existing server?
      --upgrade-socket <UPGRADE_SOCKET>
          Path to upgrade socket
      --pidfile <PIDFILE>
          Path to the pidfile, used for upgrade
  -h, --help
          Print help
  -V, --version
          Print version
```